### PR TITLE
Update snowflake.js to use the path to the Private Key

### DIFF
--- a/database/snowflake.js
+++ b/database/snowflake.js
@@ -2,22 +2,30 @@ const snowflake = require('snowflake-sdk')
 const genericPool = require("generic-pool");
 const config = require('../config')
 const crypto = require('crypto')
+var fs = require('fs');
 
 const factory = {
   create: () => {
       return new Promise((resolve, reject) => {
+          
+          // Get the private key from the file as an object.
+          const privateKeyObject = crypto.createPrivateKey({
+            key: privateKeyFile,
+            format: 'pem',
+          });
+
+          // Extract the private key from the object as a PEM-encoded string.
+          var privateKey = privateKeyObject.export({
+            format: 'pem',
+            type: 'pkcs8'
+          });
+        
           // Create Connection
           const connection = snowflake.createConnection({
             account: config.snowflake_account,
             username: config.snowflake_user,
             authenticator: 'SNOWFLAKE_JWT',
-            privateKey: crypto.createPrivateKey({
-              key: config.snowflake_private_key,
-              format: 'pem'
-            }).export({
-              format: 'pem',
-              type: 'pkcs8'
-            }),
+            privateKey: privateKey,
             database: config.snowflake_database,
             warehouse: config.snowflake_warehouse,
             clientSessionKeepAlive: true

--- a/database/snowflake.js
+++ b/database/snowflake.js
@@ -9,6 +9,7 @@ const factory = {
       return new Promise((resolve, reject) => {
           
           // Get the private key from the file as an object.
+          var privateKeyFile = fs.readFileSync(config.snowflake_private_key);
           const privateKeyObject = crypto.createPrivateKey({
             key: privateKeyFile,
             format: 'pem',


### PR DESCRIPTION
See issue #4. This is not the most efficient method to manage this as it reads the private key from disk every time, but for this example it's probably fine.